### PR TITLE
Add draggable init window

### DIFF
--- a/src/ui/main-window.blp
+++ b/src/ui/main-window.blp
@@ -17,15 +17,20 @@ template $PostboxMainWindow: Adw.ApplicationWindow {
 
     StackPage {
       name: "no-account";
-      child: Adw.StatusPage {
-        icon-name: "mail-unread-symbolic";
-        title: _("Welcome to Postbox");
-        description: _("Add a mail account to get started.");
-        child: Gtk.Button add_account_button {
-          label: _("Add Account");
-          halign: center;
+      child: Adw.ToolbarView {
+        [top]
+        Adw.HeaderBar {}
 
-          styles ["suggested-action", "pill"]
+        content: Adw.StatusPage {
+          icon-name: "mail-unread-symbolic";
+          title: _("Welcome to Postbox");
+          description: _("Add a mail account to get started.");
+          child: Gtk.Button add_account_button {
+            label: _("Add Account");
+            halign: center;
+
+            styles ["suggested-action", "pill"]
+          };
         };
       };
     }


### PR DESCRIPTION
The current project does not allow moving the initial `Add Account` Postbox initialization window. I noticed this when resizing it and trying to move it a bit before logging in. This fix adds a draggable titlebar area to the main window blueprint. This does not change the visible UI at all, it only makes it so the init window is moveable. Small change to make the initial setup a bit nicer!