### PR TITLE
Add TLS/STARTTLS Option Selection (Allows Proton Mail Bridge account support)

### DIFF
--- a/src/postcard/account_dialog.py
+++ b/src/postcard/account_dialog.py
@@ -17,6 +17,8 @@ class PostcardAccountDialog(Adw.Dialog):
     imap_port_row: Adw.EntryRow = Gtk.Template.Child()
     smtp_host_row: Adw.EntryRow = Gtk.Template.Child()
     smtp_port_row: Adw.EntryRow = Gtk.Template.Child()
+    imap_security_row: Adw.ComboRow = Gtk.Template.Child()
+    smtp_security_row: Adw.ComboRow = Gtk.Template.Child()
 
     __gsignals__ = {
         "account-added": (GObject.SignalFlags.RUN_FIRST, None, ()),
@@ -50,13 +52,16 @@ class PostcardAccountDialog(Adw.Dialog):
         self.add_button.set_sensitive(all(field.strip() for field in required))
 
     def _on_add_clicked(self, _button: Gtk.Button) -> None:
+        _sec_options = ["tls", "starttls"]
         account = self._db.save_account(
             email=self.email_row.get_text().strip(),
             display_name=self.display_name_row.get_text().strip(),
             imap_host=self.imap_host_row.get_text().strip(),
             imap_port=int(self.imap_port_row.get_text().strip()),
+            imap_security=_sec_options[self.imap_security_row.get_selected()],
             smtp_host=self.smtp_host_row.get_text().strip(),
             smtp_port=int(self.smtp_port_row.get_text().strip()),
+            smtp_security=_sec_options[self.smtp_security_row.get_selected()],
         )
 
         secrets.store_password(account.id, self.password_row.get_text())

--- a/src/postcard/core/models/account.py
+++ b/src/postcard/core/models/account.py
@@ -19,6 +19,8 @@ class Account(GObject.Object):
         imap_port: int,
         smtp_host: str,
         smtp_port: int,
+        imap_security: str = "tls",
+        smtp_security: str = "tls",
     ) -> None:
         super().__init__()
         self.id: int = id
@@ -28,3 +30,5 @@ class Account(GObject.Object):
         self.imap_port: int = imap_port
         self.smtp_host: str = smtp_host
         self.smtp_port: int = smtp_port
+        self.imap_security: str = imap_security
+        self.smtp_security: str = smtp_security

--- a/src/postcard/core/net/imap_session.py
+++ b/src/postcard/core/net/imap_session.py
@@ -9,13 +9,18 @@ class ImapError(Exception):
 
 
 class ImapSession:
-    def __init__(self, host: str, port: int) -> None:
+    def __init__(self, host: str, port: int, security: str = "tls") -> None:
         self._host = host
         self._port = port
-        self._imap: imaplib.IMAP4_SSL | None = None
+        self._security = security
+        self._imap: imaplib.IMAP4 | None = None
 
     def connect(self) -> str:
-        self._imap = imaplib.IMAP4_SSL(self._host, self._port, timeout=30)
+        if self._security == "starttls":
+            self._imap = imaplib.IMAP4(self._host, self._port, timeout=30)
+            self._imap.starttls()
+        else:
+            self._imap = imaplib.IMAP4_SSL(self._host, self._port, timeout=30)
         return self._imap.welcome.decode("utf-8", "replace")
 
     def login(self, user: str, password: str) -> None:

--- a/src/postcard/core/net/smtp_session.py
+++ b/src/postcard/core/net/smtp_session.py
@@ -6,17 +6,18 @@ class SmtpError(Exception):
 
 
 class SmtpSession:
-    def __init__(self, host: str, port: int) -> None:
+    def __init__(self, host: str, port: int, security: str = "tls") -> None:
         self._host = host
         self._port = port
+        self._security = security
         self._smtp: smtplib.SMTP | None = None
 
     def connect(self) -> None:
-        if self._port == 465:
-            self._smtp = smtplib.SMTP_SSL(self._host, self._port, timeout=30)
-        else:
+        if self._security == "starttls":
             self._smtp = smtplib.SMTP(self._host, self._port, timeout=30)
             self._smtp.starttls()
+        else:
+            self._smtp = smtplib.SMTP_SSL(self._host, self._port, timeout=30)
 
     def login(self, user: str, password: str) -> None:
         try:

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -112,11 +112,24 @@ class Database:
             INSERT INTO emails_fts(emails_fts) VALUES ('rebuild');
             """
         )
+
+        # Migration: add per-protocol security columns for existing databases.
+        for col in ("imap_security", "smtp_security"):
+            try:
+                self._conn.execute(f"ALTER TABLE accounts ADD COLUMN {col} TEXT")
+            except sqlite3.OperationalError:
+                pass  # column already exists
         self._conn.commit()
 
     # --- accounts -----------------------------------------------------------
 
     def _account_from_row(self, row: sqlite3.Row) -> Account:
+        imap_sec = row["imap_security"]
+        if imap_sec is None:
+            imap_sec = "tls"  # legacy: always used IMAP4_SSL
+        smtp_sec = row["smtp_security"]
+        if smtp_sec is None:
+            smtp_sec = "tls" if row["smtp_port"] == 465 else "starttls"
         return Account(
             id=row["id"],
             email=row["email"],
@@ -125,6 +138,8 @@ class Database:
             imap_port=row["imap_port"],
             smtp_host=row["smtp_host"],
             smtp_port=row["smtp_port"],
+            imap_security=imap_sec,
+            smtp_security=smtp_sec,
         )
 
     def accounts(self) -> list[Account]:
@@ -139,14 +154,28 @@ class Database:
         imap_port: int,
         smtp_host: str,
         smtp_port: int,
+        imap_security: str = "tls",
+        smtp_security: str | None = None,
     ) -> Account:
+        if smtp_security is None:
+            smtp_security = "tls" if smtp_port == 465 else "starttls"
         cursor = self._conn.execute(
             """
             INSERT INTO accounts
-                (email, display_name, imap_host, imap_port, smtp_host, smtp_port)
-            VALUES (?, ?, ?, ?, ?, ?)
+                (email, display_name, imap_host, imap_port, smtp_host, smtp_port,
+                 imap_security, smtp_security)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (email, display_name, imap_host, imap_port, smtp_host, smtp_port),
+            (
+                email,
+                display_name,
+                imap_host,
+                imap_port,
+                smtp_host,
+                smtp_port,
+                imap_security,
+                smtp_security,
+            ),
         )
         self._conn.commit()
 

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -119,6 +119,20 @@ class Database:
                 self._conn.execute(f"ALTER TABLE accounts ADD COLUMN {col} TEXT")
             except sqlite3.OperationalError:
                 pass  # column already exists
+
+        self._conn.execute(
+            "UPDATE accounts SET imap_security = 'tls' WHERE imap_security IS NULL"
+        )
+        self._conn.execute(
+            """
+            UPDATE accounts
+            SET smtp_security = CASE
+                WHEN smtp_port = 465 THEN 'tls'
+                ELSE 'starttls'
+            END
+            WHERE smtp_security IS NULL
+            """
+        )
         self._conn.commit()
 
     # --- accounts -----------------------------------------------------------

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -60,7 +60,9 @@ class Database:
                 imap_host TEXT NOT NULL,
                 imap_port INTEGER NOT NULL,
                 smtp_host TEXT NOT NULL,
-                smtp_port INTEGER NOT NULL
+                smtp_port INTEGER NOT NULL,
+                imap_security TEXT NOT NULL DEFAULT 'tls',
+                smtp_security TEXT NOT NULL DEFAULT 'starttls'
             );
 
             CREATE TABLE IF NOT EXISTS folders (
@@ -113,26 +115,6 @@ class Database:
             """
         )
 
-        # Migration: add per-protocol security columns for existing databases.
-        for col in ("imap_security", "smtp_security"):
-            try:
-                self._conn.execute(f"ALTER TABLE accounts ADD COLUMN {col} TEXT")
-            except sqlite3.OperationalError:
-                pass  # column already exists
-
-        self._conn.execute(
-            "UPDATE accounts SET imap_security = 'tls' WHERE imap_security IS NULL"
-        )
-        self._conn.execute(
-            """
-            UPDATE accounts
-            SET smtp_security = CASE
-                WHEN smtp_port = 465 THEN 'tls'
-                ELSE 'starttls'
-            END
-            WHERE smtp_security IS NULL
-            """
-        )
         self._conn.commit()
 
     # --- accounts -----------------------------------------------------------

--- a/src/postcard/mail_send.py
+++ b/src/postcard/mail_send.py
@@ -6,7 +6,7 @@ def send_message(
     account: Account, password: str, from_addr: str, recipients: list[str], raw: bytes
 ) -> None:
     """Connect, log in, and hand a fully-built message to the server."""
-    session = SmtpSession(account.smtp_host, account.smtp_port)
+    session = SmtpSession(account.smtp_host, account.smtp_port, account.smtp_security)
     session.connect()
 
     try:

--- a/src/postcard/mail_sync.py
+++ b/src/postcard/mail_sync.py
@@ -54,7 +54,7 @@ def fetch_mailbox(
     `offset` pages backwards: 0 is the newest `limit`, `limit` is the page
     before that (used to load older mail on scroll).
     """
-    session = ImapSession(account.imap_host, account.imap_port)
+    session = ImapSession(account.imap_host, account.imap_port, account.imap_security)
     session.connect()
 
     try:
@@ -88,7 +88,7 @@ def fetch_full_message(
     account: Account, password: str, folder_name: str, uid: str
 ) -> bytes:
     """Connect, login, open one folder, and download a single full message"""
-    session = ImapSession(account.imap_host, account.imap_port)
+    session = ImapSession(account.imap_host, account.imap_port, account.imap_security)
     session.connect()
 
     try:
@@ -108,7 +108,7 @@ def set_flag(
     add: bool,
 ) -> None:
     """Add or remove an IMAP flag on every message in a conversation."""
-    session = ImapSession(account.imap_host, account.imap_port)
+    session = ImapSession(account.imap_host, account.imap_port, account.imap_security)
     session.connect()
     try:
         session.login(account.email, password)
@@ -127,7 +127,7 @@ def move_messages(
     destination: str,
 ) -> None:
     """Move every message in a conversation to another mailbox."""
-    session = ImapSession(account.imap_host, account.imap_port)
+    session = ImapSession(account.imap_host, account.imap_port, account.imap_security)
     session.connect()
     try:
         session.login(account.email, password)

--- a/src/ui/account-dialog.blp
+++ b/src/ui/account-dialog.blp
@@ -57,6 +57,14 @@ template $PostcardAccountDialog: Adw.Dialog {
                           input-purpose: digits;
                           text: "993";
                         }
+
+                      Adw.ComboRow imap_security_row {
+                          title: _("Connection Security");
+                          model: Gtk.StringList {
+                              strings ["TLS", "STARTTLS"]
+                          };
+                          selected: 0;
+                      }
                     }
 
                   Adw.PreferencesGroup {
@@ -71,6 +79,14 @@ template $PostcardAccountDialog: Adw.Dialog {
                           input-purpose: digits;
                           text: "587";
                         }
+
+                      Adw.ComboRow smtp_security_row {
+                          title: _("Connection Security");
+                          model: Gtk.StringList {
+                              strings ["TLS", "STARTTLS"]
+                          };
+                          selected: 1;
+                      }
                     }
                 };
             };


### PR DESCRIPTION
Hello!

Sorry for the two PRs so soon, both of these fixes/features were from me getting the app setup. I use Proton Mail and their SMTP bridge locally for my mail (it encrypts / decrypts mail so you need to run their local SMTP server and not just connect directly). It uses STARTTLS as the security option, which the app currently does not allow and fails to load mail with a "Can't establish secure connection" error.

This adds support for choosing either TLS or STARTTLS for an account during setup with dropdowns. It also adds a migration to ensure the current data is moved to the new database fields in the backend (so no accounts already existing are broken).

With these changes, I can now connect to my Proton Mail account in the app and start using it!

Let me know if anything needs to be modified or if you have any feedback.

Cheers!

<img width="640" height="360" alt="Screenshot From 2026-07-19 10-02-10" src="https://github.com/user-attachments/assets/34e9b593-c976-4031-80be-551de421b18c" />
<img width="640" height="360" alt="Screenshot From 2026-07-19 10-02-05" src="https://github.com/user-attachments/assets/855a48c2-87fb-41c6-9947-df93a36a1d3e" />
