### PR TITLE
Added Folder Hierachy + (UTF-8 compatibly) (2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 
 # AI
 .claude
+opencode.jsonc

--- a/src/meson.build
+++ b/src/meson.build
@@ -42,6 +42,7 @@ postcard_sources = [
   'postcard/composer_window.py',
   'postcard/preferences_dialog.py',
   'postcard/mail_sync.py',
+  'postcard/folder_row.py',
 ]
 python_installation.install_sources(postcard_sources, subdir: 'postcard')
 

--- a/src/postcard/core/models/folder.py
+++ b/src/postcard/core/models/folder.py
@@ -11,9 +11,19 @@ from gi.repository import GObject
 class Folder(GObject.Object):
     __gtype_name__ = "PostcardFolder"
 
-    def __init__(self, id: int, account_id: int, name: str, icon_name: str) -> None:
+    def __init__(
+        self,
+        id: int,
+        account_id: int,
+        name: str,
+        icon_name: str,
+        parent_id: int | None = None,
+        delimiter: str = "/",
+    ) -> None:
         super().__init__()
         self.id: int = id
         self.account_id: int = account_id
         self.name: str = name
         self.icon_name: str = icon_name
+        self.parent_id: int | None = parent_id
+        self.delimiter: str = delimiter

--- a/src/postcard/core/models/folder.py
+++ b/src/postcard/core/models/folder.py
@@ -27,3 +27,8 @@ class Folder(GObject.Object):
         self.icon_name: str = icon_name
         self.parent_id: int | None = parent_id
         self.delimiter: str = delimiter
+
+    # Strip to the leaf name only when there is a parent row to indent under.
+    @property
+    def display_delimiter(self) -> str | None:
+        return self.delimiter if self.parent_id is not None else None

--- a/src/postcard/core/net/imap_session.py
+++ b/src/postcard/core/net/imap_session.py
@@ -50,25 +50,29 @@ class ImapSession:
             raise ImapError("not connected")
         return self._imap
 
-    def list_folders(self) -> list[str]:
-        """Return the names of the account's selectable mailboxes."""
+    def list_folders(self) -> list[tuple[str, str, str]]:
+        """Return (name, delimiter, flags) for every listed mailbox.
+
+        Unlike the previous version, *all* mailboxes are returned (including
+        \\Noselect containers) so the caller can reconstruct the hierarchy.
+        """
         typ, data = self._require_imap().list()
-        names: list[str] = []
+        result: list[tuple[str, str, str]] = []
         for raw in data:
-            # raw is bytes like:  (\HasNoChildren) "/" "INBOX"
             if not isinstance(raw, bytes):
                 continue
             line = raw.decode("utf-8", "replace")
-            match = re.match(r'\(([^)]*)\) (?:"[^"]*"|NIL) (.+)$', line)
+            match = re.match(r'\(([^)]*)\) ("[^"]*"|NIL) (.+)$', line)
             if match is None:
                 continue
-            flags, name = match.group(1), match.group(2).strip()
-            if "\\Noselect" in flags:
-                continue  # a container like "[Gmail]" you can't actually open
+            flags_part = match.group(1)
+            delim_raw = match.group(2)
+            name = match.group(3).strip()
             if name.startswith('"') and name.endswith('"'):
-                name = name[1:-1]  # strip the surrounding quotes
-            names.append(name)
-        return names
+                name = name[1:-1]
+            delimiter = delim_raw.strip('"') if delim_raw != "NIL" else "/"
+            result.append((name, delimiter, flags_part))
+        return result
 
     def select(self, mailbox: str, readonly: bool = True) -> int:
         """Open a mailbox; return how many messages it holds.

--- a/src/postcard/core/net/imap_session.py
+++ b/src/postcard/core/net/imap_session.py
@@ -12,6 +12,13 @@ def _quote_mailbox(name: str) -> str:
     return f'"{escaped}"'
 
 
+def _unquote(token: str) -> str:
+    """The inverse of _quote_mailbox: drop the quotes and backslash escapes."""
+    if token.startswith('"') and token.endswith('"'):
+        token = token[1:-1]
+    return re.sub(r"\\(.)", r"\1", token)
+
+
 class ImapError(Exception):
     """Raised when talking to the server fails (bad login, dropped link, ..)"""
 
@@ -53,8 +60,9 @@ class ImapSession:
     def list_folders(self) -> list[tuple[str, str, str]]:
         """Return (name, delimiter, flags) for every listed mailbox.
 
-        Unlike the previous version, *all* mailboxes are returned (including
-        \\Noselect containers) so the caller can reconstruct the hierarchy.
+        \\Noselect containers are included so the caller can rebuild the
+        hierarchy. The delimiter is "" when the server reports NIL, meaning a
+        flat namespace whose names must not be split into parent and child.
         """
         typ, data = self._require_imap().list()
         result: list[tuple[str, str, str]] = []
@@ -67,10 +75,8 @@ class ImapSession:
                 continue
             flags_part = match.group(1)
             delim_raw = match.group(2)
-            name = match.group(3).strip()
-            if name.startswith('"') and name.endswith('"'):
-                name = name[1:-1]
-            delimiter = delim_raw.strip('"') if delim_raw != "NIL" else "/"
+            name = _unquote(match.group(3).strip())
+            delimiter = "" if delim_raw == "NIL" else _unquote(delim_raw)
             result.append((name, delimiter, flags_part))
         return result
 

--- a/src/postcard/core/net/imap_session.py
+++ b/src/postcard/core/net/imap_session.py
@@ -1,7 +1,31 @@
+import base64
 import email
 import imaplib
 import re
 from email import policy
+from typing import NamedTuple
+
+
+class MailboxInfo(NamedTuple):
+    name: str
+    delimiter: str  # "" when the server reports NIL: a flat namespace
+    flags: str
+
+
+def decode_mailbox_name(name: str) -> str:
+    """Decode a mailbox name from modified UTF-7 (RFC 3501 5.1.3), so
+    "Entw&APw-rfe" reads as "Entwürfe"."""
+
+    def chunk(match: re.Match[str]) -> str:
+        if not match.group(1):
+            return "&"  # "&-" encodes a literal ampersand
+        try:
+            padded = match.group(1).replace(",", "/") + "==="
+            return base64.b64decode(padded).decode("utf-16-be")
+        except (ValueError, UnicodeDecodeError):
+            return "�"
+
+    return re.sub(r"&([A-Za-z0-9+,]*)-", chunk, name)
 
 
 def _quote_mailbox(name: str) -> str:
@@ -57,15 +81,15 @@ class ImapSession:
             raise ImapError("not connected")
         return self._imap
 
-    def list_folders(self) -> list[tuple[str, str, str]]:
-        """Return (name, delimiter, flags) for every listed mailbox.
+    def list_folders(self) -> list[MailboxInfo]:
+        """Return every listed mailbox.
 
         \\Noselect containers are included so the caller can rebuild the
         hierarchy. The delimiter is "" when the server reports NIL, meaning a
         flat namespace whose names must not be split into parent and child.
         """
         typ, data = self._require_imap().list()
-        result: list[tuple[str, str, str]] = []
+        result: list[MailboxInfo] = []
         for raw in data:
             if not isinstance(raw, bytes):
                 continue
@@ -77,7 +101,7 @@ class ImapSession:
             delim_raw = match.group(2)
             name = _unquote(match.group(3).strip())
             delimiter = "" if delim_raw == "NIL" else _unquote(delim_raw)
-            result.append((name, delimiter, flags_part))
+            result.append(MailboxInfo(name, delimiter, flags_part))
         return result
 
     def select(self, mailbox: str, readonly: bool = True) -> int:

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -44,6 +44,7 @@ class Database:
         self._conn.execute("PRAGMA foreign_keys = ON")
 
         self._create_tables()
+        self._migrate_schema()
 
     def close(self) -> None:
         self._conn.close()
@@ -69,7 +70,9 @@ class Database:
                 id INTEGER PRIMARY KEY,
                 account_id INTEGER NOT NULL REFERENCES accounts(id),
                 name TEXT NOT NULL,
-                icon_name TEXT NOT NULL
+                icon_name TEXT NOT NULL DEFAULT 'folder-symbolic',
+                parent_id INTEGER REFERENCES folders(id),
+                delimiter TEXT NOT NULL DEFAULT '/'
             );
 
             CREATE TABLE IF NOT EXISTS emails (
@@ -176,11 +179,10 @@ class Database:
 
     def delete_account(self, account_id: int) -> None:
         self._conn.execute(
-            """
-            DELETE FROM emails WHERE folder_id IN (
-                SELECT id FROM folders WHERE account_id = ?
-            )
-            """,
+            "UPDATE folders SET parent_id = NULL WHERE account_id = ?", (account_id,)
+        )
+        self._conn.execute(
+            "DELETE FROM emails WHERE folder_id IN (SELECT id FROM folders WHERE account_id = ?)",
             (account_id,),
         )
         self._conn.execute("DELETE FROM folders WHERE account_id = ?", (account_id,))
@@ -189,38 +191,91 @@ class Database:
 
     # --- folders -----------------------------------------------------------
 
+    def _migrate_schema(self) -> None:
+        try:
+            self._conn.execute(
+                "ALTER TABLE folders ADD COLUMN parent_id INTEGER REFERENCES folders(id)"
+            )
+        except sqlite3.OperationalError:
+            pass
+        try:
+            self._conn.execute(
+                "ALTER TABLE folders ADD COLUMN delimiter TEXT NOT NULL DEFAULT '/'"
+            )
+        except sqlite3.OperationalError:
+            pass
+        self._conn.commit()
+
+    def _folder_from_row(self, row: sqlite3.Row) -> Folder:
+        return Folder(
+            id=row["id"],
+            account_id=row["account_id"],
+            name=row["name"],
+            icon_name=row["icon_name"],
+            parent_id=row["parent_id"],
+            delimiter=row["delimiter"],
+        )
+
     def folders_for_account(self, account_id: int) -> list[Folder]:
         rows = self._conn.execute(
             "SELECT * FROM folders WHERE account_id = ? ORDER BY id", (account_id,)
         ).fetchall()
-        return [
-            Folder(
-                id=row["id"],
-                account_id=row["account_id"],
-                name=row["name"],
-                icon_name=row["icon_name"],
-            )
-            for row in rows
-        ]
+        return [self._folder_from_row(row) for row in rows]
+
+    def root_folders(self, account_id: int) -> list[Folder]:
+        rows = self._conn.execute(
+            "SELECT * FROM folders WHERE account_id = ? AND parent_id IS NULL ORDER BY id",
+            (account_id,),
+        ).fetchall()
+        return [self._folder_from_row(row) for row in rows]
+
+    def child_folders(self, parent_id: int) -> list[Folder]:
+        rows = self._conn.execute(
+            "SELECT * FROM folders WHERE parent_id = ? ORDER BY id",
+            (parent_id,),
+        ).fetchall()
+        return [self._folder_from_row(row) for row in rows]
+
+    def get_folder_by_name(self, account_id: int, name: str) -> Folder | None:
+        row = self._conn.execute(
+            "SELECT * FROM folders WHERE account_id = ? AND name = ?",
+            (account_id, name),
+        ).fetchone()
+        return self._folder_from_row(row) if row else None
 
     def get_or_create_folder(
-        self, account_id: int, name: str, icon_name: str
+        self,
+        account_id: int,
+        name: str,
+        icon_name: str = "folder-symbolic",
+        parent_id: int | None = None,
+        delimiter: str = "/",
     ) -> Folder:
         row = self._conn.execute(
             "SELECT * FROM folders WHERE account_id = ? AND name = ?",
             (account_id, name),
         ).fetchone()
         if row is not None:
+            curr_parent = row["parent_id"]
+            curr_delim = row["delimiter"]
+            if curr_parent != parent_id or curr_delim != delimiter:
+                self._conn.execute(
+                    "UPDATE folders SET parent_id = ?, delimiter = ? WHERE id = ?",
+                    (parent_id, delimiter, row["id"]),
+                )
+                self._conn.commit()
             return Folder(
                 id=row["id"],
                 account_id=row["account_id"],
                 name=row["name"],
                 icon_name=row["icon_name"],
+                parent_id=parent_id,
+                delimiter=delimiter,
             )
 
         cursor = self._conn.execute(
-            "INSERT INTO folders (account_id, name, icon_name) VALUES (?, ?, ?)",
-            (account_id, name, icon_name),
+            "INSERT INTO folders (account_id, name, icon_name, parent_id, delimiter) VALUES (?, ?, ?, ?, ?)",
+            (account_id, name, icon_name, parent_id, delimiter),
         )
         self._conn.commit()
         assert cursor.lastrowid is not None
@@ -229,7 +284,18 @@ class Database:
             account_id=account_id,
             name=name,
             icon_name=icon_name,
+            parent_id=parent_id,
+            delimiter=delimiter,
         )
+
+    def _delete_folder_tree(self, folder_id: int) -> None:
+        children = self._conn.execute(
+            "SELECT id FROM folders WHERE parent_id = ?", (folder_id,)
+        ).fetchall()
+        for child in children:
+            self._delete_folder_tree(child["id"])
+        self._conn.execute("DELETE FROM emails WHERE folder_id = ?", (folder_id,))
+        self._conn.execute("DELETE FROM folders WHERE id = ?", (folder_id,))
 
     def prune_folders(self, account_id: int, keep_names: set[str]) -> None:
         """Delete an account's folders (and their emails) whose names aren't in
@@ -241,8 +307,7 @@ class Database:
         for row in rows:
             if row["name"] in keep_names:
                 continue
-            self._conn.execute("DELETE FROM emails WHERE folder_id = ?", (row["id"],))
-            self._conn.execute("DELETE FROM folders WHERE id = ?", (row["id"],))
+            self._delete_folder_tree(row["id"])
         self._conn.commit()
 
     # --- emails -----------------------------------------------------------

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -196,7 +196,11 @@ class Database:
             "UPDATE folders SET parent_id = NULL WHERE account_id = ?", (account_id,)
         )
         self._conn.execute(
-            "DELETE FROM emails WHERE folder_id IN (SELECT id FROM folders WHERE account_id = ?)",
+            """
+            DELETE FROM emails WHERE folder_id IN (
+                SELECT id FROM folders WHERE account_id = ?
+            )
+            """,
             (account_id,),
         )
         self._conn.execute("DELETE FROM folders WHERE account_id = ?", (account_id,))
@@ -223,7 +227,11 @@ class Database:
 
     def root_folders(self, account_id: int) -> list[Folder]:
         rows = self._conn.execute(
-            "SELECT * FROM folders WHERE account_id = ? AND parent_id IS NULL ORDER BY id",
+            """
+            SELECT * FROM folders
+            WHERE account_id = ? AND parent_id IS NULL
+            ORDER BY id
+            """,
             (account_id,),
         ).fetchall()
         return [self._folder_from_row(row) for row in rows]
@@ -273,7 +281,10 @@ class Database:
             )
 
         cursor = self._conn.execute(
-            "INSERT INTO folders (account_id, name, icon_name, parent_id, delimiter) VALUES (?, ?, ?, ?, ?)",
+            """
+            INSERT INTO folders (account_id, name, icon_name, parent_id, delimiter)
+            VALUES (?, ?, ?, ?, ?)
+            """,
             (account_id, name, icon_name, parent_id, delimiter),
         )
         self._conn.commit()

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -32,6 +32,15 @@ def _arrival_key(mail: Email) -> int:
         return 2**31 - 1
 
 
+# Schema changes since the first release, applied in order. How many have run
+# is stored in PRAGMA user_version. Only ever append -- editing or reordering
+# these would give databases in the wild a different schema to new ones.
+MIGRATIONS = [
+    "ALTER TABLE folders ADD COLUMN parent_id INTEGER REFERENCES folders(id)",
+    "ALTER TABLE folders ADD COLUMN delimiter TEXT NOT NULL DEFAULT '/'",
+]
+
+
 class Database:
     def __init__(self, path: str | None = None) -> None:
         if path is None:
@@ -70,9 +79,7 @@ class Database:
                 id INTEGER PRIMARY KEY,
                 account_id INTEGER NOT NULL REFERENCES accounts(id),
                 name TEXT NOT NULL,
-                icon_name TEXT NOT NULL DEFAULT 'folder-symbolic',
-                parent_id INTEGER REFERENCES folders(id),
-                delimiter TEXT NOT NULL DEFAULT '/'
+                icon_name TEXT NOT NULL DEFAULT 'folder-symbolic'
             );
 
             CREATE TABLE IF NOT EXISTS emails (
@@ -118,6 +125,13 @@ class Database:
             """
         )
 
+        self._conn.commit()
+
+    def _migrate_schema(self) -> None:
+        version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        for i, sql in enumerate(MIGRATIONS[version:], start=version + 1):
+            self._conn.executescript(sql)
+            self._conn.execute(f"PRAGMA user_version = {i}")
         self._conn.commit()
 
     # --- accounts -----------------------------------------------------------
@@ -190,21 +204,6 @@ class Database:
         self._conn.commit()
 
     # --- folders -----------------------------------------------------------
-
-    def _migrate_schema(self) -> None:
-        try:
-            self._conn.execute(
-                "ALTER TABLE folders ADD COLUMN parent_id INTEGER REFERENCES folders(id)"
-            )
-        except sqlite3.OperationalError:
-            pass
-        try:
-            self._conn.execute(
-                "ALTER TABLE folders ADD COLUMN delimiter TEXT NOT NULL DEFAULT '/'"
-            )
-        except sqlite3.OperationalError:
-            pass
-        self._conn.commit()
 
     def _folder_from_row(self, row: sqlite3.Row) -> Folder:
         return Folder(

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -192,6 +192,8 @@ class Database:
         return self._account_from_row(row)
 
     def delete_account(self, account_id: int) -> None:
+        # Flatten the tree first: the parent_id FK rejects deleting a parent
+        # while a child still points at it.
         self._conn.execute(
             "UPDATE folders SET parent_id = NULL WHERE account_id = ?", (account_id,)
         )
@@ -267,6 +269,7 @@ class Database:
         self._conn.commit()
 
     def _delete_folder_tree(self, folder_id: int) -> None:
+        # Deepest first, for the same FK reason as delete_account.
         children = self._conn.execute(
             "SELECT id FROM folders WHERE parent_id = ?", (folder_id,)
         ).fetchall()

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -251,41 +251,18 @@ class Database:
         return self._folder_from_row(row) if row else None
 
     def get_or_create_folder(
-        self,
-        account_id: int,
-        name: str,
-        icon_name: str = "folder-symbolic",
-        parent_id: int | None = None,
-        delimiter: str = "/",
+        self, account_id: int, name: str, icon_name: str = "folder-symbolic"
     ) -> Folder:
         row = self._conn.execute(
             "SELECT * FROM folders WHERE account_id = ? AND name = ?",
             (account_id, name),
         ).fetchone()
         if row is not None:
-            curr_parent = row["parent_id"]
-            curr_delim = row["delimiter"]
-            if curr_parent != parent_id or curr_delim != delimiter:
-                self._conn.execute(
-                    "UPDATE folders SET parent_id = ?, delimiter = ? WHERE id = ?",
-                    (parent_id, delimiter, row["id"]),
-                )
-                self._conn.commit()
-            return Folder(
-                id=row["id"],
-                account_id=row["account_id"],
-                name=row["name"],
-                icon_name=row["icon_name"],
-                parent_id=parent_id,
-                delimiter=delimiter,
-            )
+            return self._folder_from_row(row)
 
         cursor = self._conn.execute(
-            """
-            INSERT INTO folders (account_id, name, icon_name, parent_id, delimiter)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (account_id, name, icon_name, parent_id, delimiter),
+            "INSERT INTO folders (account_id, name, icon_name) VALUES (?, ?, ?)",
+            (account_id, name, icon_name),
         )
         self._conn.commit()
         assert cursor.lastrowid is not None
@@ -294,9 +271,18 @@ class Database:
             account_id=account_id,
             name=name,
             icon_name=icon_name,
-            parent_id=parent_id,
-            delimiter=delimiter,
         )
+
+    # Only the sync knows a folder's real place in the server's hierarchy, so
+    # it's set explicitly here rather than defaulted by get_or_create_folder.
+    def set_folder_parent(
+        self, folder_id: int, parent_id: int | None, delimiter: str
+    ) -> None:
+        self._conn.execute(
+            "UPDATE folders SET parent_id = ?, delimiter = ? WHERE id = ?",
+            (parent_id, delimiter, folder_id),
+        )
+        self._conn.commit()
 
     def _delete_folder_tree(self, folder_id: int) -> None:
         children = self._conn.execute(

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -225,24 +225,6 @@ class Database:
         ).fetchall()
         return [self._folder_from_row(row) for row in rows]
 
-    def root_folders(self, account_id: int) -> list[Folder]:
-        rows = self._conn.execute(
-            """
-            SELECT * FROM folders
-            WHERE account_id = ? AND parent_id IS NULL
-            ORDER BY id
-            """,
-            (account_id,),
-        ).fetchall()
-        return [self._folder_from_row(row) for row in rows]
-
-    def child_folders(self, parent_id: int) -> list[Folder]:
-        rows = self._conn.execute(
-            "SELECT * FROM folders WHERE parent_id = ? ORDER BY id",
-            (parent_id,),
-        ).fetchall()
-        return [self._folder_from_row(row) for row in rows]
-
     def get_folder_by_name(self, account_id: int, name: str) -> Folder | None:
         row = self._conn.execute(
             "SELECT * FROM folders WHERE account_id = ? AND name = ?",

--- a/src/postcard/folder_row.py
+++ b/src/postcard/folder_row.py
@@ -28,7 +28,7 @@ class FolderRow(Gtk.Box):
     def bind(self, folder: Folder, unread: int) -> None:
         self._icon.set_from_icon_name(folder.icon_name)
         self._name_label.set_label(
-            mail_sync.display_name_for_folder(folder.name, folder.delimiter)
+            mail_sync.display_name_for_folder(folder.name, folder.display_delimiter)
         )
         self._badge.set_label(str(unread))
         self._badge.set_visible(unread > 0)

--- a/src/postcard/folder_row.py
+++ b/src/postcard/folder_row.py
@@ -1,0 +1,34 @@
+from gi.repository import Gtk
+
+from . import mail_sync
+from .core.models.folder import Folder
+
+
+class FolderRow(Gtk.Box):
+    __gtype_name__ = "PostcardFolderRow"
+
+    def __init__(self) -> None:
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        self.set_margin_top(6)
+        self.set_margin_bottom(6)
+        self.set_margin_start(6)
+        self.set_margin_end(6)
+
+        self._icon = Gtk.Image()
+        self.append(self._icon)
+
+        self._name_label = Gtk.Label(xalign=0, hexpand=True)
+        self.append(self._name_label)
+
+        self._badge = Gtk.Label()
+        self._badge.add_css_class("dim-label")
+        self.append(self._badge)
+
+    # Fill this row from a folder. Called every time the row is (re)used.
+    def bind(self, folder: Folder, unread: int) -> None:
+        self._icon.set_from_icon_name(folder.icon_name)
+        self._name_label.set_label(
+            mail_sync.display_name_for_folder(folder.name, folder.delimiter)
+        )
+        self._badge.set_label(str(unread))
+        self._badge.set_visible(unread > 0)

--- a/src/postcard/mail_sync.py
+++ b/src/postcard/mail_sync.py
@@ -1,9 +1,45 @@
+import base64
 from dataclasses import dataclass, field
 from email.utils import parseaddr, parsedate_to_datetime
 
 from .core.models.account import Account
 from .core.net.imap_session import ImapSession
 from .core.net.smtp_session import SmtpSession
+
+
+def _decode_imap_utf7(name: str) -> str:
+    """Decode a mailbox name from IMAP4-UTF-7 (modified UTF-7) per RFC 3501."""
+    parts: list[str] = []
+    buf: list[str] = []
+    in_base64 = False
+    for c in name:
+        if c == "&" and not in_base64:
+            in_base64 = True
+            buf = []
+        elif c == "-" and in_base64:
+            in_base64 = False
+            if not buf:
+                parts.append("&")
+            else:
+                raw = "".join(buf).replace(",", "/")
+                try:
+                    padding = 4 - len(raw) % 4
+                    if padding != 4:
+                        raw += "=" * padding
+                    parts.append(
+                        base64.b64decode(raw).decode("utf-16be", errors="replace")
+                    )
+                except Exception:
+                    parts.append("\ufffd")
+            buf = []
+        elif in_base64:
+            buf.append(c)
+        else:
+            parts.append(c)
+    if in_base64:
+        parts.append("&" + "".join(buf))
+    return "".join(parts)
+
 
 # how many recent messages to pull per sync
 RECENT_LIMIT = 50
@@ -26,6 +62,7 @@ class MessageHeader:
 @dataclass
 class SyncResult:
     folders: list[str] = field(default_factory=list)
+    folder_info: list[tuple[str, str, str]] = field(default_factory=list)
     messages: list[MessageHeader] = field(default_factory=list)
     folder: str = "INBOX"
     exists: int = 0  # total messages in the selected mailbox
@@ -60,8 +97,9 @@ def fetch_mailbox(
 
     try:
         session.login(account.email, password)
-        folders = session.list_folders()
-        target = folder or inbox_name(folders)
+        raw_folders = session.list_folders()
+        folder_names = [f[0] for f in raw_folders]
+        target = folder or inbox_name(folder_names)
         exists = session.select(target)
         raw = session.fetch_recent_headers(exists, limit, offset)
     finally:
@@ -82,7 +120,14 @@ def fetch_mailbox(
         for item in raw
     ]
 
-    return SyncResult(folders, messages, target, exists, offset)
+    return SyncResult(
+        folders=folder_names,
+        folder_info=raw_folders,
+        messages=messages,
+        folder=target,
+        exists=exists,
+        offset=offset,
+    )
 
 
 def fetch_full_message(
@@ -173,10 +218,14 @@ def role_for_folder(name: str) -> str:
     return "other"
 
 
-def display_name_for_folder(name: str) -> str:
+def display_name_for_folder(name: str, delimiter: str | None = None) -> str:
+    name = _decode_imap_utf7(name)
     for prefix in ("[Gmail]/", "[Google Mail]/"):
         if name.startswith(prefix):
-            return name[len(prefix) :]
+            name = name[len(prefix) :]
+            break
+    if delimiter:
+        name = name.rsplit(delimiter, 1)[-1]
     return name
 
 

--- a/src/postcard/mail_sync.py
+++ b/src/postcard/mail_sync.py
@@ -1,45 +1,9 @@
-import base64
 from dataclasses import dataclass, field
 from email.utils import parseaddr, parsedate_to_datetime
 
 from .core.models.account import Account
-from .core.net.imap_session import ImapSession
+from .core.net.imap_session import ImapSession, MailboxInfo, decode_mailbox_name
 from .core.net.smtp_session import SmtpSession
-
-
-def _decode_imap_utf7(name: str) -> str:
-    """Decode a mailbox name from IMAP4-UTF-7 (modified UTF-7) per RFC 3501."""
-    parts: list[str] = []
-    buf: list[str] = []
-    in_base64 = False
-    for c in name:
-        if c == "&" and not in_base64:
-            in_base64 = True
-            buf = []
-        elif c == "-" and in_base64:
-            in_base64 = False
-            if not buf:
-                parts.append("&")
-            else:
-                raw = "".join(buf).replace(",", "/")
-                try:
-                    padding = 4 - len(raw) % 4
-                    if padding != 4:
-                        raw += "=" * padding
-                    parts.append(
-                        base64.b64decode(raw).decode("utf-16be", errors="replace")
-                    )
-                except Exception:
-                    parts.append("\ufffd")
-            buf = []
-        elif in_base64:
-            buf.append(c)
-        else:
-            parts.append(c)
-    if in_base64:
-        parts.append("&" + "".join(buf))
-    return "".join(parts)
-
 
 # how many recent messages to pull per sync
 RECENT_LIMIT = 50
@@ -61,12 +25,15 @@ class MessageHeader:
 
 @dataclass
 class SyncResult:
-    folders: list[str] = field(default_factory=list)
-    folder_info: list[tuple[str, str, str]] = field(default_factory=list)
+    folders: list[MailboxInfo] = field(default_factory=list)
     messages: list[MessageHeader] = field(default_factory=list)
     folder: str = "INBOX"
     exists: int = 0  # total messages in the selected mailbox
     offset: int = 0  # how far back from the newest this fetch reached
+
+    @property
+    def folder_names(self) -> list[str]:
+        return [f.name for f in self.folders]
 
 
 def inbox_name(folders: list[str]) -> str:
@@ -97,9 +64,8 @@ def fetch_mailbox(
 
     try:
         session.login(account.email, password)
-        raw_folders = session.list_folders()
-        folder_names = [f[0] for f in raw_folders]
-        target = folder or inbox_name(folder_names)
+        mailboxes = session.list_folders()
+        target = folder or inbox_name([m.name for m in mailboxes])
         exists = session.select(target)
         raw = session.fetch_recent_headers(exists, limit, offset)
     finally:
@@ -121,8 +87,7 @@ def fetch_mailbox(
     ]
 
     return SyncResult(
-        folders=folder_names,
-        folder_info=raw_folders,
+        folders=mailboxes,
         messages=messages,
         folder=target,
         exists=exists,
@@ -219,7 +184,7 @@ def role_for_folder(name: str) -> str:
 
 
 def display_name_for_folder(name: str, delimiter: str | None = None) -> str:
-    name = _decode_imap_utf7(name)
+    name = decode_mailbox_name(name)
     for prefix in ("[Gmail]/", "[Google Mail]/"):
         if name.startswith(prefix):
             name = name[len(prefix) :]

--- a/src/postcard/mail_sync.py
+++ b/src/postcard/mail_sync.py
@@ -8,6 +8,10 @@ from .core.net.smtp_session import SmtpSession
 # how many recent messages to pull per sync
 RECENT_LIMIT = 50
 
+# Gmail nests its special folders under an unselectable "[Gmail]" container.
+# It isn't a real mailbox, so it's hidden and its children sit at the top level.
+NAMESPACE_ROOTS = ("[Gmail]", "[Google Mail]")
+
 
 @dataclass
 class MessageHeader:
@@ -30,10 +34,6 @@ class SyncResult:
     folder: str = "INBOX"
     exists: int = 0  # total messages in the selected mailbox
     offset: int = 0  # how far back from the newest this fetch reached
-
-    @property
-    def folder_names(self) -> list[str]:
-        return [f.name for f in self.folders]
 
 
 def inbox_name(folders: list[str]) -> str:
@@ -183,11 +183,17 @@ def role_for_folder(name: str) -> str:
     return "other"
 
 
+def parent_mailbox_name(name: str, delimiter: str) -> str:
+    """The mailbox enclosing name, or "" when it sits at the top level."""
+    parent = name.rpartition(delimiter)[0] if delimiter else ""
+    return "" if parent in NAMESPACE_ROOTS else parent
+
+
 def display_name_for_folder(name: str, delimiter: str | None = None) -> str:
     name = decode_mailbox_name(name)
-    for prefix in ("[Gmail]/", "[Google Mail]/"):
-        if name.startswith(prefix):
-            name = name[len(prefix) :]
+    for root in NAMESPACE_ROOTS:
+        if name.startswith(root + "/"):
+            name = name[len(root) + 1 :]
             break
     if delimiter:
         name = name.rsplit(delimiter, 1)[-1]

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -807,6 +807,9 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         if self._current_folder is None:
             return
 
+        vadj = self.conversation_scroller.get_vadjustment()
+        scroll_pos = vadj.get_value() if vadj else 0.0
+
         query = self.search_entry.get_text().strip()
         if query:
             matches = self._db.search_conversations(self._current_folder.id, query)
@@ -843,6 +846,14 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         else:
             self._selection.unselect_all()
             self._update_reader()
+
+        if vadj is not None and scroll_pos > 0:
+            GLib.idle_add(
+                lambda: vadj.set_value(
+                    min(scroll_pos, vadj.get_upper() - vadj.get_page_size())
+                )
+                or False
+            )
 
     # Debounce keystrokes: query the database ~200ms after typing stops instead
     # of on every letter.
@@ -1250,9 +1261,17 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         if result.folders:
             self._db.prune_folders(self._account_id, set(result.folders) | {"Outbox"})
 
-        target = self._db.get_or_create_folder(
-            self._account_id, result.folder, mail_sync.icon_for_folder(result.folder)
-        )
+        # The loop above already created/updated this folder with the right
+        # parent/delimiter. Look it up instead of re-calling get_or_create_folder
+        # with defaults, which would reset a nested folder's parent_id to NULL
+        # and make it jump to the end of the root list.
+        target = self._db.get_folder_by_name(self._account_id, result.folder)
+        if target is None:
+            target = self._db.get_or_create_folder(
+                self._account_id,
+                result.folder,
+                mail_sync.icon_for_folder(result.folder),
+            )
         new_messages: list[mail_sync.MessageHeader] = []
         for message in result.messages:
             added = self._db.save_incoming_email(
@@ -1403,18 +1422,6 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         self._folder_root_store.remove_all()
         for folder in self._db.root_folders(self._account_id):
             self._folder_root_store.append(folder)
-
-        self._folder_tree_model = Gtk.TreeListModel.new(
-            self._folder_root_store,
-            False,
-            True,
-            self._folder_children_func,
-            None,
-            None,
-        )
-        self._folder_selection = Gtk.SingleSelection(model=self._folder_tree_model)
-        self._folder_selection.connect("selection-changed", self._on_folder_selected)
-        self.folder_list.set_model(self._folder_selection)
 
         if keep_id is not None:
             self._select_folder_by_id(keep_id)

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -50,7 +50,7 @@ class PostcardMainWindow(Adw.ApplicationWindow):
     # These fields are filled in automatically from the widgets we named in
     # main-window.blp. The attribute name must match the id in the Blueprint
     # file exactly.
-    folder_list: Gtk.ListBox = Gtk.Template.Child()
+    folder_list: Gtk.ListView = Gtk.Template.Child()
     conversation_list: Gtk.ListView = Gtk.Template.Child()
     conversation_scroller: Gtk.ScrolledWindow = Gtk.Template.Child()
     conversation_stack: Gtk.Stack = Gtk.Template.Child()
@@ -112,8 +112,7 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         self.unread_button.connect("toggled", self._on_unread_toggled)
 
         # Connected once here (not per account load) so switching accounts
-        # doesn't stack duplicate handlers.
-        self.folder_list.connect("row-selected", self._on_folder_selected)
+        # doesn't stack duplicate handlers or CSS providers.
 
         self.connection_banner.connect("button-clicked", self._on_banner_retry)
         self._network = Gio.NetworkMonitor.get_default()
@@ -160,9 +159,24 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         self.main_stack.set_visible_child_name("mail")
         self._refresh_account_switcher()
 
-        self._folders: Gio.ListStore = Gio.ListStore(item_type=Folder)
-        for folder in self._db.folders_for_account(self._account_id):
-            self._folders.append(folder)
+        self._folder_root_store: Gio.ListStore = Gio.ListStore(item_type=Folder)
+        for folder in self._db.root_folders(self._account_id):
+            self._folder_root_store.append(folder)
+
+        self._folder_tree_model: Gtk.TreeListModel = Gtk.TreeListModel.new(
+            self._folder_root_store,
+            False,
+            True,
+            self._folder_children_func,
+            None,
+            None,
+        )
+        self._folder_selection: Gtk.SingleSelection = Gtk.SingleSelection(
+            model=self._folder_tree_model
+        )
+        self._folder_selection.connect(
+            "selection-changed", self._on_folder_selected
+        )
 
         # One persistent store, mutated in place via splice() on every
         # refresh: swapping in a new Gio.ListStore each time (the previous
@@ -617,7 +631,7 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         for folder in self._db.folders_for_account(self._account_id):
             if folder.id == current_id:
                 continue
-            label = mail_sync.display_name_for_folder(folder.name)
+            label = mail_sync.display_name_for_folder(folder.name, folder.delimiter)
             item = Gio.MenuItem.new(label, None)
             item.set_action_and_target_value(
                 "win.move", GLib.Variant.new_string(folder.name)
@@ -671,25 +685,65 @@ class PostcardMainWindow(Adw.ApplicationWindow):
 
         return menu
 
-    # The folder list is small and fixed, so a Gtk.ListBox is the simplest
-    # tool. bind_model() builds one row per folder and keeps them in sync with
-    # the store for free.
-    def _setup_folder_sidebar(self) -> None:
-        self.folder_list.bind_model(self._folders, self._build_folder_row)
-
-    def _build_folder_row(self, item: GObject.Object) -> Gtk.Widget:
+    def _folder_children_func(
+        self, item: GObject.Object, *_args: object
+    ) -> Gio.ListStore | None:
         folder = item
         assert isinstance(folder, Folder)
+        children = self._db.child_folders(folder.id)
+        if not children:
+            return None
+        store = Gio.ListStore(item_type=Folder)
+        for child in children:
+            store.append(child)
+        return store
 
+    def _setup_folder_sidebar(self) -> None:
+        self.folder_list.set_model(self._folder_selection)
+        factory = Gtk.SignalListItemFactory()
+        factory.connect("setup", self._on_folder_row_setup)
+        factory.connect("bind", self._on_folder_row_bind)
+        factory.connect("unbind", self._on_folder_row_unbind)
+        self.folder_list.set_factory(factory)
+
+    def _on_folder_row_setup(
+        self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem
+    ) -> None:
+        expander = Gtk.TreeExpander()
         box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         box.set_margin_top(6)
         box.set_margin_bottom(6)
         box.set_margin_start(6)
         box.set_margin_end(6)
+        expander.set_child(box)
+        item.set_child(expander)
+
+    def _on_folder_row_bind(
+        self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem
+    ) -> None:
+        expander = item.get_child()
+        assert isinstance(expander, Gtk.TreeExpander)
+
+        tree_list_row = item.get_item()
+        assert isinstance(tree_list_row, Gtk.TreeListRow)
+        expander.set_list_row(tree_list_row)
+
+        folder = tree_list_row.get_item()
+        assert isinstance(folder, Folder)
+
+        box = expander.get_child()
+        assert isinstance(box, Gtk.Box)
+
+        child = box.get_first_child()
+        while child is not None:
+            nxt = child.get_next_sibling()
+            box.remove(child)
+            child = nxt
+
         box.append(Gtk.Image.new_from_icon_name(folder.icon_name))
 
         name = Gtk.Label(
-            label=mail_sync.display_name_for_folder(folder.name),
+            label=mail_sync.display_name_for_folder(folder.name, folder.delimiter),
             xalign=0,
             hexpand=True,
         )
@@ -701,28 +755,39 @@ class PostcardMainWindow(Adw.ApplicationWindow):
             badge.add_css_class("dim-label")
             box.append(badge)
 
-        return box
+    def _on_folder_row_unbind(
+        self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem
+    ) -> None:
+        expander = item.get_child()
+        if isinstance(expander, Gtk.TreeExpander):
+            expander.set_list_row(None)
 
-    # Select the inbox row (or the first folder if we can't spot one).
     def _select_inbox_row(self) -> None:
+        n = self._folder_tree_model.get_n_items()
+        if n == 0:
+            return
         target = 0
-        for i in range(self._folders.get_n_items()):
-            folder = self._folders.get_item(i)
-            assert isinstance(folder, Folder)
-            if mail_sync.role_for_folder(folder.name) == "inbox":
-                target = i
-                break
-        row = self.folder_list.get_row_at_index(target)
-        if row is not None:
-            self.folder_list.select_row(row)
+        for i in range(n):
+            tree_row = self._folder_tree_model.get_item(i)
+            if isinstance(tree_row, Gtk.TreeListRow):
+                folder = tree_row.get_item()
+                assert isinstance(folder, Folder)
+                if mail_sync.role_for_folder(folder.name) == "inbox":
+                    target = i
+                    break
+        self._folder_selection.set_selected(target)
 
     def _on_folder_selected(
-        self, _list_box: Gtk.ListBox, row: Gtk.ListBoxRow | None
+        self,
+        selection: Gtk.SingleSelection,
+        _position: int,
+        _n_items: int,
     ) -> None:
-        if row is None:
+        tree_list_row = selection.get_selected_item()
+        if not isinstance(tree_list_row, Gtk.TreeListRow):
             return
 
-        folder = self._folders.get_item(row.get_index())
+        folder = tree_list_row.get_item()
         assert isinstance(folder, Folder)
         previous = self._current_folder
         self._current_folder = folder
@@ -730,10 +795,6 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         if self._suppress_folder_refresh:
             return
         self._refresh_conversations()
-        # Show cached mail instantly, then pull this folder from the server.
-        # Guard on a real folder change: rebuilding the sidebar re-emits
-        # row-selected for the same folder (sometimes after the suppress flag is
-        # cleared), which would otherwise sync in a tight loop.
         changed = previous is None or previous.id != folder.id
         if changed and self._online:
             self._start_sync(background=True, folder_name=folder.name)
@@ -1173,12 +1234,19 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         selected = self._selection.get_selected_item()
         keep_id = selected.id if isinstance(selected, Conversation) else None
 
-        for name in result.folders:
+        sorted_info = sorted(result.folder_info, key=lambda x: len(x[0]))
+        for name, delimiter, flags_str in sorted_info:
+            is_selectable = "\\Noselect" not in flags_str
+            icon = mail_sync.icon_for_folder(name) if is_selectable else "folder-symbolic"
+            parts = name.rsplit(delimiter, 1)
+            parent_id: int | None = None
+            if len(parts) > 1:
+                parent = self._db.get_folder_by_name(self._account_id, parts[0])
+                if parent is not None:
+                    parent_id = parent.id
             self._db.get_or_create_folder(
-                self._account_id, name, mail_sync.icon_for_folder(name)
+                self._account_id, name, icon, parent_id=parent_id, delimiter=delimiter
             )
-        # Mirror the server's folder list, keeping only the local Outbox. This
-        # clears stale rows like a duplicate "INBOX" from earlier versions.
         if result.folders:
             self._db.prune_folders(self._account_id, set(result.folders) | {"Outbox"})
 
@@ -1327,26 +1395,43 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         else:
             self.sync_spinner.stop()
 
-    # Rebuild the folder sidebar (refreshes the unread badges). Re-selecting the
-    # row is suppressed so it doesn't rebuild the conversation list — callers
-    # that want that refresh it explicitly.
     def _reload_folders(self) -> None:
-        # Preserve the selection by folder id, not row index — pruning stale
-        # folders can shift the indices.
         keep_id = self._current_folder.id if self._current_folder else None
 
         self._suppress_folder_refresh = True
-        self._folders.remove_all()
-        target = 0
-        for i, folder in enumerate(self._db.folders_for_account(self._account_id)):
-            self._folders.append(folder)
-            if folder.id == keep_id:
-                target = i
 
-        row = self.folder_list.get_row_at_index(target)
-        if row is not None:
-            self.folder_list.select_row(row)
+        self._folder_root_store.remove_all()
+        for folder in self._db.root_folders(self._account_id):
+            self._folder_root_store.append(folder)
+
+        self._folder_tree_model = Gtk.TreeListModel.new(
+            self._folder_root_store,
+            False,
+            True,
+            self._folder_children_func,
+            None,
+            None,
+        )
+        self._folder_selection = Gtk.SingleSelection(model=self._folder_tree_model)
+        self._folder_selection.connect("selection-changed", self._on_folder_selected)
+        self.folder_list.set_model(self._folder_selection)
+
+        if keep_id is not None:
+            self._select_folder_by_id(keep_id)
+
         self._suppress_folder_refresh = False
+
+    def _select_folder_by_id(self, folder_id: int) -> None:
+        n = self._folder_tree_model.get_n_items()
+        if n == 0:
+            return
+        for i in range(n):
+            tree_row = self._folder_tree_model.get_item(i)
+            if isinstance(tree_row, Gtk.TreeListRow):
+                f = tree_row.get_item()
+                if isinstance(f, Folder) and f.id == folder_id:
+                    self._folder_selection.set_selected(i)
+                    return
 
     def _toast(self, text: str) -> None:
         self.toast_overlay.add_toast(Adw.Toast(title=text))

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -40,6 +40,7 @@ from .core.models.conversation import Conversation
 from .core.models.email import Email
 from .core.models.folder import Folder
 from .core.store.database import Database
+from .folder_row import FolderRow
 from .message_view import MessageView
 
 
@@ -161,7 +162,7 @@ class PostcardMainWindow(Adw.ApplicationWindow):
 
         # Boxes of the rows currently on screen, keyed by folder id, so
         # _reload_folders can refresh them without rebuilding the tree.
-        self._folder_rows: dict[int, Gtk.Box] = {}
+        self._folder_rows: dict[int, FolderRow] = {}
         # The (id, parent_id) pairs the tree was last built from.
         self._folder_shape: list[tuple[int, int | None]] = []
 
@@ -709,18 +710,17 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         factory.connect("unbind", self._on_folder_row_unbind)
         self.folder_list.set_factory(factory)
 
+    # setup: build one empty widget, reused for many folders as the list
+    # scrolls. The expander draws the indent and the expand/collapse arrow.
     def _on_folder_row_setup(
         self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem
     ) -> None:
         expander = Gtk.TreeExpander()
-        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-        box.set_margin_top(6)
-        box.set_margin_bottom(6)
-        box.set_margin_start(6)
-        box.set_margin_end(6)
-        expander.set_child(box)
+        expander.set_child(FolderRow())
         item.set_child(expander)
 
+    # bind: fill an existing widget from its item. Runs on every scroll, so it
+    # only copies fields across.
     def _on_folder_row_bind(
         self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem
     ) -> None:
@@ -734,33 +734,11 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         folder = tree_list_row.get_item()
         assert isinstance(folder, Folder)
 
-        box = expander.get_child()
-        assert isinstance(box, Gtk.Box)
+        row = expander.get_child()
+        assert isinstance(row, FolderRow)
 
-        self._folder_rows[folder.id] = box
-        self._fill_folder_row(box, folder)
-
-    def _fill_folder_row(self, box: Gtk.Box, folder: Folder) -> None:
-        child = box.get_first_child()
-        while child is not None:
-            nxt = child.get_next_sibling()
-            box.remove(child)
-            child = nxt
-
-        box.append(Gtk.Image.new_from_icon_name(folder.icon_name))
-
-        name = Gtk.Label(
-            label=mail_sync.display_name_for_folder(folder.name, folder.delimiter),
-            xalign=0,
-            hexpand=True,
-        )
-        box.append(name)
-
-        count = self._db.unread_count_in_folder(folder.id)
-        if count > 0:
-            badge = Gtk.Label(label=str(count))
-            badge.add_css_class("dim-label")
-            box.append(badge)
+        self._folder_rows[folder.id] = row
+        row.bind(folder, self._db.unread_count_in_folder(folder.id))
 
     def _on_folder_row_unbind(
         self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem
@@ -1436,9 +1414,9 @@ class PostcardMainWindow(Adw.ApplicationWindow):
             self._rebuild_folder_tree()
 
         for folder in folders:
-            box = self._folder_rows.get(folder.id)
-            if box is not None:
-                self._fill_folder_row(box, folder)
+            row = self._folder_rows.get(folder.id)
+            if row is not None:
+                row.bind(folder, self._db.unread_count_in_folder(folder.id))
 
     def _rebuild_folder_tree(self) -> None:
         keep_id = self._current_folder.id if self._current_folder else None

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -159,10 +159,13 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         self.main_stack.set_visible_child_name("mail")
         self._refresh_account_switcher()
 
-        self._folder_root_store: Gio.ListStore = Gio.ListStore(item_type=Folder)
-        for folder in self._db.root_folders(self._account_id):
-            self._folder_root_store.append(folder)
+        # Boxes of the rows currently on screen, keyed by folder id, so
+        # _reload_folders can refresh them without rebuilding the tree.
+        self._folder_rows: dict[int, Gtk.Box] = {}
+        # The (id, parent_id) pairs the tree was last built from.
+        self._folder_shape: list[tuple[int, int | None]] = []
 
+        self._folder_root_store: Gio.ListStore = Gio.ListStore(item_type=Folder)
         self._folder_tree_model: Gtk.TreeListModel = Gtk.TreeListModel.new(
             self._folder_root_store,
             False,
@@ -174,9 +177,7 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         self._folder_selection: Gtk.SingleSelection = Gtk.SingleSelection(
             model=self._folder_tree_model
         )
-        self._folder_selection.connect(
-            "selection-changed", self._on_folder_selected
-        )
+        self._folder_selection.connect("selection-changed", self._on_folder_selected)
 
         # One persistent store, mutated in place via splice() on every
         # refresh: swapping in a new Gio.ListStore each time (the previous
@@ -189,6 +190,8 @@ class PostcardMainWindow(Adw.ApplicationWindow):
 
         self._setup_folder_sidebar()
         self._setup_conversation_list()
+
+        self._reload_folders()
 
         # Selecting the inbox kicks off a network fetch for it via
         # _on_folder_selected; the sync below only bootstraps a fresh account
@@ -734,6 +737,10 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         box = expander.get_child()
         assert isinstance(box, Gtk.Box)
 
+        self._folder_rows[folder.id] = box
+        self._fill_folder_row(box, folder)
+
+    def _fill_folder_row(self, box: Gtk.Box, folder: Folder) -> None:
         child = box.get_first_child()
         while child is not None:
             nxt = child.get_next_sibling()
@@ -758,6 +765,12 @@ class PostcardMainWindow(Adw.ApplicationWindow):
     def _on_folder_row_unbind(
         self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem
     ) -> None:
+        tree_list_row = item.get_item()
+        if isinstance(tree_list_row, Gtk.TreeListRow):
+            folder = tree_list_row.get_item()
+            if isinstance(folder, Folder):
+                self._folder_rows.pop(folder.id, None)
+
         expander = item.get_child()
         if isinstance(expander, Gtk.TreeExpander):
             expander.set_list_row(None)
@@ -1414,11 +1427,28 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         else:
             self.sync_spinner.stop()
 
+    # Rebuilding the tree destroys every row, which resets the user's
+    # expand/collapse state, so only rebuild when the folders or their nesting
+    # actually changed. A plain badge/icon update refreshes the rows in place.
     def _reload_folders(self) -> None:
+        folders = self._db.folders_for_account(self._account_id)
+
+        shape = [(f.id, f.parent_id) for f in folders]
+        if shape != self._folder_shape:
+            self._folder_shape = shape
+            self._rebuild_folder_tree()
+
+        for folder in folders:
+            box = self._folder_rows.get(folder.id)
+            if box is not None:
+                self._fill_folder_row(box, folder)
+
+    def _rebuild_folder_tree(self) -> None:
         keep_id = self._current_folder.id if self._current_folder else None
 
         self._suppress_folder_refresh = True
 
+        self._folder_rows.clear()
         self._folder_root_store.remove_all()
         for folder in self._db.root_folders(self._account_id):
             self._folder_root_store.append(folder)

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -1241,25 +1241,29 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         selected = self._selection.get_selected_item()
         keep_id = selected.id if isinstance(selected, Conversation) else None
 
+        mailboxes = [
+            m for m in result.folders if m.name not in mail_sync.NAMESPACE_ROOTS
+        ]
+
         # Shortest name first: a parent's name is a prefix of its children's, so
         # every parent is stored before a child looks it up.
-        for mailbox in sorted(result.folders, key=lambda m: len(m.name)):
+        for mailbox in sorted(mailboxes, key=lambda m: len(m.name)):
             name, delimiter = mailbox.name, mailbox.delimiter
             selectable = "\\Noselect" not in mailbox.flags
             icon = mail_sync.icon_for_folder(name) if selectable else "folder-symbolic"
             folder = self._db.get_or_create_folder(self._account_id, name, icon)
-            parent_id: int | None = None
-            if delimiter and delimiter in name:
-                parent = self._db.get_folder_by_name(
-                    self._account_id, name.rsplit(delimiter, 1)[0]
-                )
-                parent_id = parent.id if parent else None
-            self._db.set_folder_parent(folder.id, parent_id, delimiter)
-        if result.folders:
+
+            parent_name = mail_sync.parent_mailbox_name(name, delimiter)
+            parent = self._db.get_folder_by_name(self._account_id, parent_name)
+            self._db.set_folder_parent(
+                folder.id, parent.id if parent else None, delimiter
+            )
+
+        if mailboxes:
             # Mirror the server's folder list, keeping only the local Outbox.
             # This clears stale rows like a duplicate "INBOX" from earlier
             # versions.
-            names = set(result.folder_names) | {"Outbox"}
+            names = {m.name for m in mailboxes} | {"Outbox"}
             self._db.prune_folders(self._account_id, names)
 
         target = self._db.get_or_create_folder(

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -1248,7 +1248,7 @@ class PostcardMainWindow(Adw.ApplicationWindow):
             )
             folder = self._db.get_or_create_folder(self._account_id, name, icon)
             parent_id: int | None = None
-            if delimiter in name:
+            if delimiter and delimiter in name:
                 parent = self._db.get_folder_by_name(
                     self._account_id, name.rsplit(delimiter, 1)[0]
                 )

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -862,10 +862,12 @@ class PostcardMainWindow(Adw.ApplicationWindow):
 
         if vadj is not None and scroll_pos > 0:
             GLib.idle_add(
-                lambda: vadj.set_value(
-                    min(scroll_pos, vadj.get_upper() - vadj.get_page_size())
+                lambda: (
+                    vadj.set_value(
+                        min(scroll_pos, vadj.get_upper() - vadj.get_page_size())
+                    )
+                    or False
                 )
-                or False
             )
 
     # Debounce keystrokes: query the database ~200ms after typing stops instead
@@ -1261,7 +1263,9 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         sorted_info = sorted(result.folder_info, key=lambda x: len(x[0]))
         for name, delimiter, flags_str in sorted_info:
             is_selectable = "\\Noselect" not in flags_str
-            icon = mail_sync.icon_for_folder(name) if is_selectable else "folder-symbolic"
+            icon = (
+                mail_sync.icon_for_folder(name) if is_selectable else "folder-symbolic"
+            )
             parts = name.rsplit(delimiter, 1)
             parent_id: int | None = None
             if len(parts) > 1:

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -165,6 +165,8 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         self._folder_rows: dict[int, FolderRow] = {}
         # The (id, parent_id) pairs the tree was last built from.
         self._folder_shape: list[tuple[int, int | None]] = []
+        # Folders grouped by parent id; None holds the roots.
+        self._folder_children: dict[int | None, list[Folder]] = {}
 
         self._folder_root_store: Gio.ListStore = Gio.ListStore(item_type=Folder)
         self._folder_tree_model: Gtk.TreeListModel = Gtk.TreeListModel.new(
@@ -694,9 +696,8 @@ class PostcardMainWindow(Adw.ApplicationWindow):
     def _folder_children_func(
         self, item: GObject.Object, *_args: object
     ) -> Gio.ListStore | None:
-        folder = item
-        assert isinstance(folder, Folder)
-        children = self._db.child_folders(folder.id)
+        assert isinstance(item, Folder)
+        children = self._folder_children.get(item.id)
         if not children:
             return None
         store = Gio.ListStore(item_type=Folder)
@@ -1242,12 +1243,10 @@ class PostcardMainWindow(Adw.ApplicationWindow):
 
         # Shortest name first: a parent's name is a prefix of its children's, so
         # every parent is stored before a child looks it up.
-        sorted_info = sorted(result.folder_info, key=lambda f: len(f[0]))
-        for name, delimiter, flags_str in sorted_info:
-            is_selectable = "\\Noselect" not in flags_str
-            icon = (
-                mail_sync.icon_for_folder(name) if is_selectable else "folder-symbolic"
-            )
+        for mailbox in sorted(result.folders, key=lambda m: len(m.name)):
+            name, delimiter = mailbox.name, mailbox.delimiter
+            selectable = "\\Noselect" not in mailbox.flags
+            icon = mail_sync.icon_for_folder(name) if selectable else "folder-symbolic"
             folder = self._db.get_or_create_folder(self._account_id, name, icon)
             parent_id: int | None = None
             if delimiter and delimiter in name:
@@ -1257,7 +1256,8 @@ class PostcardMainWindow(Adw.ApplicationWindow):
                 parent_id = parent.id if parent else None
             self._db.set_folder_parent(folder.id, parent_id, delimiter)
         if result.folders:
-            self._db.prune_folders(self._account_id, set(result.folders) | {"Outbox"})
+            names = set(result.folder_names) | {"Outbox"}
+            self._db.prune_folders(self._account_id, names)
 
         target = self._db.get_or_create_folder(
             self._account_id, result.folder, mail_sync.icon_for_folder(result.folder)
@@ -1410,6 +1410,10 @@ class PostcardMainWindow(Adw.ApplicationWindow):
     def _reload_folders(self) -> None:
         folders = self._db.folders_for_account(self._account_id)
 
+        self._folder_children = {}
+        for folder in folders:
+            self._folder_children.setdefault(folder.parent_id, []).append(folder)
+
         shape = [(f.id, f.parent_id) for f in folders]
         if shape != self._folder_shape:
             self._folder_shape = shape
@@ -1427,7 +1431,7 @@ class PostcardMainWindow(Adw.ApplicationWindow):
 
         self._folder_rows.clear()
         self._folder_root_store.remove_all()
-        for folder in self._db.root_folders(self._account_id):
+        for folder in self._folder_children.get(None, []):
             self._folder_root_store.append(folder)
 
         if keep_id is not None:

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -1260,35 +1260,28 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         selected = self._selection.get_selected_item()
         keep_id = selected.id if isinstance(selected, Conversation) else None
 
-        sorted_info = sorted(result.folder_info, key=lambda x: len(x[0]))
+        # Shortest name first: a parent's name is a prefix of its children's, so
+        # every parent is stored before a child looks it up.
+        sorted_info = sorted(result.folder_info, key=lambda f: len(f[0]))
         for name, delimiter, flags_str in sorted_info:
             is_selectable = "\\Noselect" not in flags_str
             icon = (
                 mail_sync.icon_for_folder(name) if is_selectable else "folder-symbolic"
             )
-            parts = name.rsplit(delimiter, 1)
+            folder = self._db.get_or_create_folder(self._account_id, name, icon)
             parent_id: int | None = None
-            if len(parts) > 1:
-                parent = self._db.get_folder_by_name(self._account_id, parts[0])
-                if parent is not None:
-                    parent_id = parent.id
-            self._db.get_or_create_folder(
-                self._account_id, name, icon, parent_id=parent_id, delimiter=delimiter
-            )
+            if delimiter in name:
+                parent = self._db.get_folder_by_name(
+                    self._account_id, name.rsplit(delimiter, 1)[0]
+                )
+                parent_id = parent.id if parent else None
+            self._db.set_folder_parent(folder.id, parent_id, delimiter)
         if result.folders:
             self._db.prune_folders(self._account_id, set(result.folders) | {"Outbox"})
 
-        # The loop above already created/updated this folder with the right
-        # parent/delimiter. Look it up instead of re-calling get_or_create_folder
-        # with defaults, which would reset a nested folder's parent_id to NULL
-        # and make it jump to the end of the root list.
-        target = self._db.get_folder_by_name(self._account_id, result.folder)
-        if target is None:
-            target = self._db.get_or_create_folder(
-                self._account_id,
-                result.folder,
-                mail_sync.icon_for_folder(result.folder),
-            )
+        target = self._db.get_or_create_folder(
+            self._account_id, result.folder, mail_sync.icon_for_folder(result.folder)
+        )
         new_messages: list[mail_sync.MessageHeader] = []
         for message in result.messages:
             added = self._db.save_incoming_email(

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -112,9 +112,6 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         )
         self.unread_button.connect("toggled", self._on_unread_toggled)
 
-        # Connected once here (not per account load) so switching accounts
-        # doesn't stack duplicate handlers or CSS providers.
-
         self.connection_banner.connect("button-clicked", self._on_banner_retry)
         self._network = Gio.NetworkMonitor.get_default()
         self._online = self._network.get_network_available()
@@ -756,6 +753,7 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         if isinstance(expander, Gtk.TreeExpander):
             expander.set_list_row(None)
 
+    # Select the inbox row, or the first folder if we can't spot one.
     def _select_inbox_row(self) -> None:
         n = self._folder_tree_model.get_n_items()
         if n == 0:
@@ -789,6 +787,8 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         if self._suppress_folder_refresh:
             return
         self._refresh_conversations()
+        # Only sync on a real folder change — rebuilding the sidebar re-emits
+        # selection-changed for the same folder, which would loop.
         changed = previous is None or previous.id != folder.id
         if changed and self._online:
             self._start_sync(background=True, folder_name=folder.name)
@@ -1256,6 +1256,9 @@ class PostcardMainWindow(Adw.ApplicationWindow):
                 parent_id = parent.id if parent else None
             self._db.set_folder_parent(folder.id, parent_id, delimiter)
         if result.folders:
+            # Mirror the server's folder list, keeping only the local Outbox.
+            # This clears stale rows like a duplicate "INBOX" from earlier
+            # versions.
             names = set(result.folder_names) | {"Outbox"}
             self._db.prune_folders(self._account_id, names)
 
@@ -1425,6 +1428,9 @@ class PostcardMainWindow(Adw.ApplicationWindow):
                 row.bind(folder, self._db.unread_count_in_folder(folder.id))
 
     def _rebuild_folder_tree(self) -> None:
+        # Preserve the selection by folder id, not row index — pruning stale
+        # folders shifts the indices. Re-selecting is suppressed so it doesn't
+        # rebuild the conversation list; callers refresh that explicitly.
         keep_id = self._current_folder.id if self._current_folder else None
 
         self._suppress_folder_refresh = True

--- a/src/postcard/window.py
+++ b/src/postcard/window.py
@@ -635,7 +635,9 @@ class PostcardMainWindow(Adw.ApplicationWindow):
         for folder in self._db.folders_for_account(self._account_id):
             if folder.id == current_id:
                 continue
-            label = mail_sync.display_name_for_folder(folder.name, folder.delimiter)
+            label = mail_sync.display_name_for_folder(
+                folder.name, folder.display_delimiter
+            )
             item = Gio.MenuItem.new(label, None)
             item.set_action_and_target_value(
                 "win.move", GLib.Variant.new_string(folder.name)

--- a/src/ui/main-window.blp
+++ b/src/ui/main-window.blp
@@ -70,9 +70,7 @@ template $PostcardMainWindow: Adw.ApplicationWindow {
             content: Gtk.ScrolledWindow {
               hscrollbar-policy: never;
 
-              child: Gtk.ListBox folder_list {
-                selection-mode: single;
-
+              child: Gtk.ListView folder_list {
                 styles ["navigation-sidebar"]
               };
             };


### PR DESCRIPTION
# INFO
This is a second pr, because I wanted to create a second one but would have to base future ones on this commit. So i had to rebase my main onto 5f99bbcad94d407adebf0d84cb9c07952c2fb2d7 (v1.2.0)

This is on another safe branch. 

So I want to apologies myself for that extra work.

# Previous PR
Hi there So after further inspection i wanted to help you a little bit.


I added a Folder Hierachy. To do this I had to expand the Database, touch the imap session and mail_sync

There is also an ai summery:


---
**The problem:** The folder sidebar was a flat `Gtk.ListBox`. If your IMAP
server had nested folders like `Work/Project/Active` or
`[Gmail]/Sent Mail`, every folder appeared as a flat, un-indented list
item. You couldn't tell which was a parent and which was a child, the
full path was shown as the label, and non-ASCII folder names like
`Entwürfe` showed up as garbled IMAP encoding like `Entw&APw-rfe`.

---

### `Folder` model
Gave every folder two new fields: `parent_id` (links a child folder to
its parent row in the DB) and `delimiter` (the character the server uses
between levels, usually `/`). This is the foundation for a tree.

### Database
Extended the `folders` table with `parent_id` and `delimiter` columns.
Added `root_folders()` and `child_folders()` queries so the UI can ask
"give me the top-level folders" and "give me the children of this one".
`prune_folders()` now deletes recursively so children don't orphan. A
`_migrate_schema()` handles adding the columns to existing databases
without losing data.

### IMAP session
`list_folders()` used to return just a list of names, dropping
`\Noselect` containers (like `[Gmail]` itself). Now it returns
`(name, delimiter, flags)` tuples and keeps everything, so the sync
layer can figure out which folder is whose parent and which ones
aren't selectable.

### Sync
`SyncResult` now carries the raw folder metadata alongside the flat
name list. `fetch_mailbox` passes both through. In `_on_sync_done`, we
sort folders shallowest-first so parents exist before children, then
store each with its `parent_id`. `\Noselect` containers get a generic
icon instead of a mail icon.

### Sidebar UI
The old `Gtk.ListBox` was replaced with `Gtk.TreeListModel` +
`Gtk.ListView`. The sidebar now shows a real tree: nested folders are
indented, each parent has an expand/collapse arrow, and all nodes start
expanded. Selecting a folder and syncing works the same as before, but
the tree state is rebuilt cleanly on every reload.

The old `_build_folder_row` that created a widget once and returned it
was replaced with the `Gtk.SignalListItemFactory` pattern: one widget
is set up once, then recycled for each row via `bind`/`unbind`. A
`Gtk.TreeExpander` wraps the row content and handles the indent + arrow
automatically.

### UTF-8 names
IMAP servers deliver non-ASCII folder names in modified UTF-7.
`display_name_for_folder()` in `mail_sync.py` now decodes them
(`Entw&APw-rfe` → `Entwürfe`, `&2D3c5w-` → `📧`). Since every other
layer already passes names through as-is (the DB stores whatever the
server said, and `_quote_mailbox` sends it back verbatim), this single
decode point in the display function fixes the whole pipeline — no
encoder needed.

### Leaf-name display
`display_name_for_folder()` now accepts an optional `delimiter`. When
called from the sidebar or move menu, it strips everything before the
last delimiter, so `Work/Project/Active` shows as just `Active`. The
tree indentation already makes the hierarchy clear, so the full path
in the label was just noise.
