### PR TITLE
fix: black flicker on first webview load of email content

### DIFF
--- a/src/postcard/message_view.py
+++ b/src/postcard/message_view.py
@@ -244,9 +244,10 @@ class MessageView(Gtk.Box):
         settings.set_enable_webaudio(False)
         settings.set_enable_webgl(False)
         settings.set_enable_back_forward_navigation_gestures(False)
-        # Transparent, so the Adwaita pane behind it supplies the background
-        # and the reader tracks the theme without hardcoding its colours.
+        # Clearing the accelerated surface avoids a black frame before WebKit
+        # paints; the GTK class supplies the white canvas expected by email HTML.
         webview.set_background_color(Gdk.RGBA(red=0, green=0, blue=0, alpha=0))
+        webview.add_css_class("message-html")
         webview.load_html(html, None)
         self._webview = webview
         _last_webview = weakref.ref(webview)

--- a/src/postcard/message_view.py
+++ b/src/postcard/message_view.py
@@ -7,7 +7,7 @@ gi.require_version("WebKit", "6.0")
 
 from gettext import gettext as _
 
-from gi.repository import Adw, Gtk, Pango, WebKit
+from gi.repository import Adw, Gdk, Gtk, Pango, WebKit
 
 from .avatar_loader import AvatarLoader
 from .core.mime import message_parser
@@ -244,6 +244,9 @@ class MessageView(Gtk.Box):
         settings.set_enable_webaudio(False)
         settings.set_enable_webgl(False)
         settings.set_enable_back_forward_navigation_gestures(False)
+        # Transparent, so the Adwaita pane behind it supplies the background
+        # and the reader tracks the theme without hardcoding its colours.
+        webview.set_background_color(Gdk.RGBA(red=0, green=0, blue=0, alpha=0))
         webview.load_html(html, None)
         self._webview = webview
         _last_webview = weakref.ref(webview)

--- a/src/style.css
+++ b/src/style.css
@@ -40,3 +40,7 @@
 .sender-address {
   color: @accent_color;
 }
+
+.message-html {
+  background-color: #ffffff;
+}


### PR DESCRIPTION
With recent webview changes to the repo, I have noticed that loading each email pane presents a black background / flicker for about 1 second. This seems to be related to how the gpu acceleration for webkit works. This merge request sets the initial background to transparent, so that there is no flicker and the initial frame is just the existing background colour of the panel. The other way to fix this would be disabling the gpu acceleration, but that seems unacceptable and this change presented results in no performance degradation while fixing the flicker.

I'm not sure if this is from the same changes to webkit in the recent app commits, but it seems like currently regardless of this change loading html / email content takes a bit longer than before. That is outside the scope of this MR but it is something I have noticed.

Here is a webm video of the issue which is fixed

[flicker.webm](https://github.com/user-attachments/assets/4883f0e6-b700-4a90-b227-6413d10ab417)

