### PR TITLE
docs: add CONTRIBUTING.md for dev workflow setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Postcard
+
+Thanks for taking a look! This covers how to get a dev environment running.
+For the project's architecture and conventions, see [CLAUDE.md](CLAUDE.md).
+
+## Easiest way: GNOME Builder
+
+1. Install [GNOME Builder](https://flathub.org/en/apps/org.gnome.Builder) from Flathub.
+2. Open this repo's folder in Builder.
+3. Builder reads `in.gxanshu.postcard.json` and offers to install the SDK it
+   recommends — accept it.
+4. Hit the ▶ Run button.
+
+That's it — no terminal needed. Builder builds and runs the Flatpak for you on
+every change.
+
+## The terminal way: `just`
+
+Everything else goes through [`just`](https://github.com/casey/just) as a
+thin wrapper around the same Flatpak toolchain Builder uses. There is no
+host-level `python app.py` — Python, GTK, and meson all come from the GNOME
+SDK. You'll need `flatpak` and `flatpak-builder` installed on your system.
+
+```bash
+just init      # one-time: add Flathub, install the GNOME runtime + SDK
+just run       # build from your working tree and launch it — the normal dev loop
+```
+
+`just init` only needs to run once per machine. After that, `just run` is the
+loop: it rebuilds from whatever is in your working tree (uncommitted edits
+included) and launches the app.
+
+A few more recipes worth knowing:
+
+```bash
+just build     # build + install, without launching
+just run-debug # run with G_MESSAGES_DEBUG=all
+just inspect   # run with the GTK Inspector open
+just check     # ruff check + ruff format --check + pyright
+just test      # run the test suite (also runs `check` first)
+just fmt       # auto-format with ruff
+just bundle    # produce a single-file postcard-<version>.flatpak
+```
+
+Run `just` with no arguments any time to see the full recipe list.
+
+## Before you submit
+
+Code contributions should pass `just check` and `just test` — `just build`
+and `just run` depend on both, so a lint, type, or test failure blocks the
+Flatpak build itself, not just CI.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ inbox is different. Code contributions should pass `just check` and `just test`;
 work is fine here (see the [AI Notice](#ai-notice) above), but please make sure you understand
 every line you submit.
 
+New to the codebase? See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up a dev
+environment — either open the folder in [GNOME Builder](https://flathub.org/en/apps/org.gnome.Builder)
+and let it install the SDK it suggests, or use `just init` / `just run` from a terminal.
+
 If Postcard is useful to you, a ⭐ helps other people find it.
 
 ## License


### PR DESCRIPTION
## Summary

Adds a concise `CONTRIBUTING.md` covering how to set up a dev environment for Postcard, and links it from the README's Contributing section.

- **Easiest path:** open the repo in [GNOME Builder](https://flathub.org/en/apps/org.gnome.Builder), let it install the SDK it suggests from the manifest, and hit Run.
- **Terminal path:** `just init` once, then `just run` as the normal dev loop, plus a quick reference for `build`, `run-debug`, `inspect`, `check`, `test`, `fmt`, and `bundle`.
- README's Contributing section now points new contributors at `CONTRIBUTING.md`.

## Testing

Documentation-only change; no code paths touched. `just check`/`just test` are unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EenDofjEpoDP7zgUuzdyQg)_