### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gxanshu/postcard/security/code-scanning/1](https://github.com/gxanshu/postcard/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/tests.yml` at the workflow root (top level), so it applies to all jobs unless overridden. For this workflow, the minimal and appropriate permission is:

- `contents: read`

This preserves existing functionality (`actions/checkout` and read-only CI tasks) while restricting token capabilities.

Concretely, insert the block between the `on:` triggers and `jobs:` (or anywhere at root level). No imports, methods, or additional definitions are needed—only YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
