### PR TITLE
feat: sign in with a username separate from the email address

### DIFF
--- a/src/postcard/account_dialog.py
+++ b/src/postcard/account_dialog.py
@@ -13,6 +13,7 @@ class PostcardAccountDialog(Adw.Dialog):
     add_button: Gtk.Button = Gtk.Template.Child()
     display_name_row: Adw.EntryRow = Gtk.Template.Child()
     email_row: Adw.EntryRow = Gtk.Template.Child()
+    username_row: Adw.EntryRow = Gtk.Template.Child()
     password_row: Adw.PasswordEntryRow = Gtk.Template.Child()
     imap_host_row: Adw.EntryRow = Gtk.Template.Child()
     imap_port_row: Adw.EntryRow = Gtk.Template.Child()
@@ -32,12 +33,13 @@ class PostcardAccountDialog(Adw.Dialog):
         self.cancel_button.connect("clicked", lambda _b: self.close())
         self.add_button.connect("clicked", self._on_add_clicked)
 
-        # Values we put in the server fields ourselves, so a later autofill can
-        # tell its own text from something the user typed and never clobber it.
+        # Values we put in the fields ourselves, so a later autofill can tell
+        # its own text from something the user typed and never clobber it.
         # Seeded with the template's defaults, which count as ours.
         self._autofilled_text = {
             row: row.get_text()
             for row in (
+                self.username_row,
                 self.imap_host_row,
                 self.imap_port_row,
                 self.smtp_host_row,
@@ -48,6 +50,7 @@ class PostcardAccountDialog(Adw.Dialog):
             combo: combo.get_selected()
             for combo in (self.imap_security_row, self.smtp_security_row)
         }
+        self.email_row.connect("changed", self._autofill_username)
         self.email_row.connect("changed", self._autofill_servers)
 
         for row in (
@@ -60,6 +63,15 @@ class PostcardAccountDialog(Adw.Dialog):
             self.smtp_port_row,
         ):
             row.connect("changed", self._update_add_sensitivity)
+
+    def _autofill_username(self, *_args: object) -> None:
+        # Kept apart from _autofill_servers, which gives up on any domain it
+        # does not recognise: the address is a sensible username for every
+        # server, known provider or not.
+        email = self.email_row.get_text()
+        if self.username_row.get_text() == self._autofilled_text[self.username_row]:
+            self.username_row.set_text(email)
+            self._autofilled_text[self.username_row] = email
 
     def _autofill_servers(self, *_args: object) -> None:
         settings = providers.settings_for_email(self.email_row.get_text())
@@ -123,6 +135,7 @@ class PostcardAccountDialog(Adw.Dialog):
             smtp_host=self.smtp_host_row.get_text().strip(),
             smtp_port=smtp_port,
             smtp_security=SECURITY_OPTIONS[self.smtp_security_row.get_selected()],
+            username=self.username_row.get_text().strip(),
         )
 
         secrets.store_password(account.id, self.password_row.get_text())

--- a/src/postcard/core/models/account.py
+++ b/src/postcard/core/models/account.py
@@ -42,6 +42,7 @@ class Account(GObject.Object):
         smtp_port: int,
         imap_security: str = "tls",
         smtp_security: str = "tls",
+        username: str = "",
         goa_id: str = "",
     ) -> None:
         super().__init__()
@@ -54,6 +55,9 @@ class Account(GObject.Object):
         self.smtp_port: int = smtp_port
         self.imap_security: str = imap_security
         self.smtp_security: str = smtp_security
+        # The name the server wants at sign-in, when that is not the address the
+        # mail is addressed to. Empty means the two are the same.
+        self.username: str = username
         # Set when the account came from GNOME Online Accounts, which is then
         # where its credentials live instead of the keyring.
         self.goa_id: str = goa_id
@@ -62,3 +66,12 @@ class Account(GObject.Object):
     def short_label(self) -> str:
         # Free to be a nickname: outgoing mail puts email in From:, never this.
         return self.display_name.strip() or self.email.partition("@")[0]
+
+    @property
+    def login_name(self) -> str:
+        """What to sign in with: the address, unless the server wants its own.
+
+        Accounts saved before there was a username field have it empty, so the
+        fallback is also what keeps those signing in unchanged.
+        """
+        return self.username or self.email

--- a/src/postcard/core/secrets.py
+++ b/src/postcard/core/secrets.py
@@ -47,4 +47,4 @@ def credential_for(account: Account) -> Credential | None:
         return goa.credential(account.goa_id)
 
     password = lookup_password(account.id)
-    return Credential(account.email, password) if password else None
+    return Credential(account.login_name, password) if password else None

--- a/src/postcard/core/store/database.py
+++ b/src/postcard/core/store/database.py
@@ -83,6 +83,9 @@ MIGRATIONS = [
     # _create_tables, which runs on every launch: no indexed column is ever
     # updated, so once is enough and a rebuild costs the whole table.
     "INSERT INTO emails_fts(emails_fts) VALUES ('rebuild')",
+    # No backfill: empty already means "sign in as the email address", which is
+    # what every account predating this column was doing.
+    "ALTER TABLE accounts ADD COLUMN username TEXT NOT NULL DEFAULT ''",
 ]
 
 
@@ -205,6 +208,7 @@ class Database:
             smtp_port=row["smtp_port"],
             imap_security=row["imap_security"],
             smtp_security=row["smtp_security"],
+            username=row["username"],
             goa_id=row["goa_id"],
         )
 
@@ -222,6 +226,7 @@ class Database:
         smtp_port: int,
         imap_security: str = SECURITY_TLS,
         smtp_security: str | None = None,
+        username: str = "",
         goa_id: str = "",
     ) -> Account:
         if smtp_security is None:
@@ -234,8 +239,8 @@ class Database:
             """
             INSERT INTO accounts
                 (email, display_name, imap_host, imap_port, smtp_host, smtp_port,
-                 imap_security, smtp_security, goa_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 imap_security, smtp_security, username, goa_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 email,
@@ -246,6 +251,7 @@ class Database:
                 smtp_port,
                 imap_security,
                 smtp_security,
+                username,
                 goa_id,
             ),
         )

--- a/src/ui/account-dialog.blp
+++ b/src/ui/account-dialog.blp
@@ -30,6 +30,7 @@ template $PostcardAccountDialog: Adw.Dialog {
               child: Adw.PreferencesPage {
                   Adw.PreferencesGroup {
                       title: _("Account");
+                      description: _("Most servers sign you in with your email address. Change the username if yours expects a different one.");
 
                       Adw.EntryRow display_name_row {
                           title: _("Display Name");
@@ -38,6 +39,10 @@ template $PostcardAccountDialog: Adw.Dialog {
                       Adw.EntryRow email_row {
                           title: _("Email Address");
                           input-purpose: email;
+                        }
+
+                      Adw.EntryRow username_row {
+                          title: _("Username");
                         }
 
                       Adw.PasswordEntryRow password_row {

--- a/tests/core/models/test_account.py
+++ b/tests/core/models/test_account.py
@@ -8,16 +8,18 @@ from postcard.core.models.account import (
 )
 
 
-def account(display_name: str) -> Account:
-    return Account(
-        id=1,
-        email="ada@example.com",
-        display_name=display_name,
-        imap_host="imap.example.com",
-        imap_port=993,
-        smtp_host="smtp.example.com",
-        smtp_port=587,
-    )
+def account(display_name: str = "Ada", **overrides) -> Account:
+    """An Account with its required fields filled in, to vary one of them."""
+    fields = {
+        "id": 1,
+        "email": "ada@example.com",
+        "display_name": display_name,
+        "imap_host": "imap.example.com",
+        "imap_port": 993,
+        "smtp_host": "smtp.example.com",
+        "smtp_port": 587,
+    }
+    return Account(**(fields | overrides))
 
 
 def test_parses_a_plain_port() -> None:
@@ -68,3 +70,16 @@ def test_short_label_falls_back_to_the_local_part() -> None:
 
 def test_short_label_ignores_a_whitespace_only_display_name() -> None:
     assert account("   ").short_label == "ada"
+
+
+def test_an_account_signs_in_as_its_email_address_by_default() -> None:
+    # Also the state of every account saved before there was a username column.
+    assert account().login_name == "ada@example.com"
+
+
+def test_a_username_overrides_the_email_address_for_sign_in() -> None:
+    # The address you send from need not be the name the server knows you by:
+    # a preferred alias is rarely the login for the mailbox behind it.
+    signed_in = account(email="ada.lovelace@example.com", username="lovelace.a")
+    assert signed_in.login_name == "lovelace.a"
+    assert signed_in.email == "ada.lovelace@example.com"

--- a/tests/core/store/test_database.py
+++ b/tests/core/store/test_database.py
@@ -89,6 +89,17 @@ def test_an_account_remembers_the_online_account_it_came_from(db):
     assert (listed_typed_in.id, listed_typed_in.goa_id) == (typed_in.id, "")
 
 
+def test_an_account_remembers_the_username_it_signs_in_with(db):
+    db.save_account("a@x", "A", "imap.x", 993, "smtp.x", 587, username="a.short")
+    db.save_account("b@x", "B", "imap.x", 993, "smtp.x", 587)
+
+    named, unnamed = db.accounts()
+    assert (named.username, named.login_name) == ("a.short", "a.short")
+    # Left blank, the address is the login -- which is what every account
+    # written before the username column has, so they sign in unchanged.
+    assert (unnamed.username, unnamed.login_name) == ("", "b@x")
+
+
 def test_an_explicit_smtp_security_wins(db):
     account = db.save_account(
         "a@x", "A", "imap.x", 993, "smtp.x", 465, smtp_security="starttls"


### PR DESCRIPTION
### The problem

Postcard signs in with the account's email address — `Credential(account.email, password)` in `core/secrets.py`. That's right whenever the login and the address are the same, but often they aren't:

- My university signs me in as `ferrali.r@univ-amu.fr`, while the address I want to send from is `romain.ferrali@univ-amu.fr` — an alias for the same mailbox.
- Plenty of universities and ISPs use a short login (`jsmith`, `u123456`) that isn't an address at all.

The only way in today is to put the login in the Email Address field. Postcard then treats that as your identity — it's what the account displays as, and what goes into every `From:` header. There's no way to use the address you actually want.

### The change

`Account` gains a `username`, with a `login_name` property that falls back to the address:

```python
@property
def login_name(self) -> str:
    return self.username or self.email
```

Empty means "the address is the login", which is what the migration leaves every existing account with — so nothing changes for anyone who didn't need this. It's the same convention `goa_id` already uses in that table.

The dialog gets a Username row that fills itself from the email as you type and backs off the moment you edit it, reusing the `_autofilled_text` bookkeeping the server fields already use. It is deliberately not one of the Add button's required fields.

It's a separate handler from `_autofill_servers` on purpose: that one returns early for any domain it doesn't recognise, so folding the username into it would mean no autofill for exactly the servers most likely to need a distinct login.

One field rather than separate IMAP and SMTP names — `Credential` carries a single user and both sessions take the same one. Straightforward to split if a server ever needs two.

### Notes

- `just check` and `just test` pass; three tests added.
- The migration is appended rather than inserted, so existing databases pick it up. I checked that one upgrades with its accounts intact and `login_name` unchanged.
- I widened the `account()` helper in `tests/core/models/test_account.py` to take keyword overrides instead of adding a second builder beside it; the existing `short_label` tests call it unchanged.
- Left `po/postcard.pot` alone, since it doesn't look like it's regenerated per feature — happy to include it if you'd rather.

Written with AI assistance; I've been through the diff and can speak to every line of it.
